### PR TITLE
Fix opencv build system

### DIFF
--- a/libflandmark/CMakeLists.txt
+++ b/libflandmark/CMakeLists.txt
@@ -1,31 +1,15 @@
 find_package( OpenCV REQUIRED )
 include_directories(${OpenCV_INCLUDE_DIRS})
 
-if(${OpenCV_VERSION_MINOR} LESS 3)
-	if (UNIX)
-		set(CV_LIBS_1 cxcore cv cvaux)
-	elseif (WIN32)
-		set(CV_LIBS_1 cxxore${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH} cv${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH} cvaux${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH})
-	elseif (APPLE)
-	endif (UNIX)
-else(${OpenCV_VERSION_MINOR} LESS 3)
-	if (UNIX)
-		set(CV_LIBS_1 opencv_core opencv_imgproc)
-	elseif (WIN32)
-		set(CV_LIBS_1 opencv_core${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH} opencv_imgproc${OpenCV_VERSION_MAJOR}${OpenCV_VERSION_MINOR}${OpenCV_VERSION_PATCH})
-	elseif (APPLE)
-	endif (UNIX)
-endif(${OpenCV_VERSION_MINOR} LESS 3)
-
 add_library(flandmark_static STATIC flandmark_detector.cpp flandmark_detector.h liblbp.cpp liblbp.h)
-target_link_libraries(flandmark_static ${CV_LIBS_1})
+target_link_libraries(flandmark_static ${OpenCV_LIBS})
 if(CMAKE_COMPILER_IS_GNUCC)
     set_target_properties(flandmark_static PROPERTIES COMPILE_FLAGS -fPIC)
 endif(CMAKE_COMPILER_IS_GNUCC)
 set_property(TARGET flandmark_static PROPERTY COMPILE_DEFINITIONS FLANDMARK_STATIC)
 
 add_library(flandmark_shared SHARED flandmark_detector.cpp flandmark_detector.h liblbp.cpp liblbp.h)
-target_link_libraries(flandmark_shared ${CV_LIBS_1})
+target_link_libraries(flandmark_shared ${OpenCV_LIBS})
 
 #setup Config.cmake
 SET(FLANDMARK_BASE_DIR "${PROJECT_SOURCE_DIR}/libflandmark")


### PR DESCRIPTION
In any case please apply the first thunk, typo precluding compilation of libflandmark without additional include paths. Keep in mind that CMake variables are case-sensitive. There are in fact 2 typos, s#OPENCV#OpenCV# s#DIR#DIRS#.

The second thunk ensures that all dependent objects get linked in; on Windows, OpenCV has a static 3rdparty zlib dependency which breaks shared build. This thunk may be dubious however as it's enlarging shared binary without -Wl,-as-needed or -flto. Gets rid of platform-specific stuff however.
