### PR TITLE
Use correct index order. rows,cols not reverse

### DIFF
--- a/libflandmark/flandmark_detector.cpp
+++ b/libflandmark/flandmark_detector.cpp
@@ -1096,7 +1096,7 @@ int flandmark_get_normalized_image_frame(IplImage *input, const int bbox[], doub
 	{
 		for (int y = 0; y < model->data.options.bw[1]; ++y)
 		{
-            face_img[INDEX(x, y, model->data.options.bw[1])] = (uint8_t)((resizedImage->imageData + resizedImage->widthStep*x)[y]);
+            face_img[INDEX(y, x, model->data.options.bw[1])] = (uint8_t)((resizedImage->imageData + resizedImage->widthStep*y)[x]);
 		}
 	}
 


### PR DESCRIPTION
Spotted-by: berak px1704@web.de
GitHub: github issue #11

My software, @sthalik/headtracker, depends on proper behavior wrt this typo.

It uses a CAD model instead of Haar every frame. As said by @berak, it only works in @uricamic/flandmark if  bbox is rectangular.
