### PR TITLE
fixed legacy opencv includes

### DIFF
--- a/libflandmark/flandmark_detector.cpp
+++ b/libflandmark/flandmark_detector.cpp
@@ -16,6 +16,8 @@
 #include "liblbp.h"
 #include "flandmark_detector.h"
 
+#include "opencv2/imgproc/imgproc_c.h"
+
 void flandmark_write_model(const char* filename, FLANDMARK_Model* model)
 {
 	int * p_int = 0, tsize = -1, tmp_tsize = -1;

--- a/libflandmark/flandmark_detector.h
+++ b/libflandmark/flandmark_detector.h
@@ -12,8 +12,10 @@
 #define __FLANDMARK_DETECTOR_H_
 
 #include "msvc-compat.h"
-#include <cv.h>
-#include <cvaux.h>
+//#include <cv.h>
+#include "opencv2/core/core_c.h"
+#include "opencv2/imgproc/types_c.h"
+//#include <cvaux.h>
 
 // index row-order matrices
 #define INDEX(ROW, COL, NUM_ROWS) ((COL)*(NUM_ROWS)+(ROW))


### PR DESCRIPTION
Removed some legacy opencv includes, that are no longer required, and are not available in certain platforms (i.e. iOS and Android).
